### PR TITLE
Fix #31: only plot valid positions

### DIFF
--- a/src/main/java/org/traccar/web/client/i18n/Messages.java
+++ b/src/main/java/org/traccar/web/client/i18n/Messages.java
@@ -129,6 +129,8 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     String recordTrace();
 
     String timePrintInterval();
+    
+    String showInvalidPositions();
 
     String trackerServerLog();
 

--- a/src/main/java/org/traccar/web/client/view/UserSettingsDialog.java
+++ b/src/main/java/org/traccar/web/client/view/UserSettingsDialog.java
@@ -17,15 +17,6 @@ package org.traccar.web.client.view;
 
 import java.util.Arrays;
 
-import com.sencha.gxt.widget.core.client.form.NumberField;
-import com.sencha.gxt.widget.core.client.form.NumberPropertyEditor;
-import com.sencha.gxt.widget.core.client.form.validator.MaxNumberValidator;
-import com.sencha.gxt.widget.core.client.form.validator.MinNumberValidator;
-import org.traccar.web.client.i18n.Messages;
-import org.traccar.web.client.model.EnumKeyProvider;
-import org.traccar.web.client.model.UserSettingsProperties;
-import org.traccar.web.shared.model.UserSettings;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.editor.client.SimpleBeanEditorDriver;
@@ -33,20 +24,31 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Widget;
+
 import com.sencha.gxt.cell.core.client.form.ComboBoxCell.TriggerAction;
 import com.sencha.gxt.data.shared.ListStore;
-import com.sencha.gxt.widget.core.client.Window;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.form.CheckBox;
 import com.sencha.gxt.widget.core.client.form.ComboBox;
+import com.sencha.gxt.widget.core.client.form.NumberField;
+import com.sencha.gxt.widget.core.client.form.NumberPropertyEditor;
+import com.sencha.gxt.widget.core.client.form.validator.MaxNumberValidator;
+import com.sencha.gxt.widget.core.client.form.validator.MinNumberValidator;
+import com.sencha.gxt.widget.core.client.Window;
+
+import org.traccar.web.client.i18n.Messages;
+import org.traccar.web.client.model.EnumKeyProvider;
+import org.traccar.web.client.model.UserSettingsProperties;
+import org.traccar.web.shared.model.UserSettings;
 
 public class UserSettingsDialog implements Editor<UserSettings> {
 
-    private static UserSettingsDialogUiBinder uiBinder = GWT.create(UserSettingsDialogUiBinder.class);
+    private static final UserSettingsDialogUiBinder uiBinder = GWT.create(UserSettingsDialogUiBinder.class);
 
     interface UserSettingsDialogUiBinder extends UiBinder<Widget, UserSettingsDialog> {
     }
 
-    private UserSettingsDriver driver = GWT.create(UserSettingsDriver.class);
+    private final UserSettingsDriver driver = GWT.create(UserSettingsDriver.class);
 
     interface UserSettingsDriver extends SimpleBeanEditorDriver<UserSettings, UserSettingsDialog> {
     }
@@ -69,6 +71,9 @@ public class UserSettingsDialog implements Editor<UserSettings> {
 
     @UiField
     NumberField<Short> timePrintInterval;
+
+    @UiField(provided = true)
+    CheckBox showInvalidPositions;
 
     @UiField(provided = true)
     NumberPropertyEditor<Short> shortPropertyEditor = new NumberPropertyEditor.ShortPropertyEditor();
@@ -105,6 +110,9 @@ public class UserSettingsDialog implements Editor<UserSettings> {
                 speedUnitStore, new UserSettingsProperties.SpeedUnitLabelProvider());
         speedUnit.setForceSelection(true);
         speedUnit.setTriggerAction(TriggerAction.ALL);
+ 
+        showInvalidPositions = new CheckBox();
+        showInvalidPositions.setValue(userSettings.getShowInvalidPositions());
 
         ListStore<UserSettings.MapType> mapTypeStore = new ListStore<UserSettings.MapType>(
                 new EnumKeyProvider<UserSettings.MapType>());

--- a/src/main/java/org/traccar/web/client/view/UserSettingsDialog.ui.xml
+++ b/src/main/java/org/traccar/web/client/view/UserSettingsDialog.ui.xml
@@ -3,9 +3,9 @@
     xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:gxt="urn:import:com.sencha.gxt.widget.core.client"
-  	xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
-  	xmlns:form="urn:import:com.sencha.gxt.widget.core.client.form"
-  	xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button">
+    xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
+    xmlns:form="urn:import:com.sencha.gxt.widget.core.client.form"
+    xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button">
 
   <ui:with type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData" field="verticalLayoutData">
     <ui:attributes width="1" height="-1" />
@@ -41,6 +41,13 @@
                               allowDecimals="false"
                               allowBlank="false"
                               width="4" />
+          </form:widget>
+        </form:FieldLabel>
+      </container:child>
+      <container:child layoutData="{verticalLayoutData}">
+        <form:FieldLabel>
+          <form:widget>
+            <form:CheckBox ui:field="showInvalidPositions" boxLabel="{i18n.showInvalidPositions}" enabled="true" />
           </form:widget>
         </form:FieldLabel>
       </container:child>

--- a/src/main/java/org/traccar/web/server/model/DBMigrations.java
+++ b/src/main/java/org/traccar/web/server/model/DBMigrations.java
@@ -94,6 +94,18 @@ public class DBMigrations {
     }
 
     /**
+     * set up showInvalidPositions flag in user settings
+     */
+    static class SetShowInvalidPositions implements Migration {
+        @Override
+        public void migrate(EntityManager em) throws Exception {
+            em.createQuery("UPDATE " + UserSettings.class.getSimpleName() + " S SET S.showInvalidPositions = :pip WHERE S.showInvalidPositions IS NULL")
+                    .setParameter("pip", UserSettings.DEFAULT_SHOW_INVALID_POSITIONS)
+                    .executeUpdate();
+        }
+    }
+
+    /**
      * set up default map view settings
      */
     static class SetDefaultMapViewSettings implements Migration {

--- a/src/main/java/org/traccar/web/shared/model/UserSettings.java
+++ b/src/main/java/org/traccar/web/shared/model/UserSettings.java
@@ -23,6 +23,7 @@ public class UserSettings implements Serializable {
     public static final int DEFAULT_ZOOM_LEVEL = 1;
     public static final double DEFAULT_CENTER_LONGITUDE = 12.5;
     public static final double DEFAULT_CENTER_LATITUDE = 41.9;
+    public static final boolean DEFAULT_SHOW_INVALID_POSITIONS = true;  // Current behavior
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,6 +37,7 @@ public class UserSettings implements Serializable {
         centerLongitude = DEFAULT_CENTER_LONGITUDE;
         centerLatitude = DEFAULT_CENTER_LATITUDE;
         mapType = MapType.OSM;
+        showInvalidPositions = DEFAULT_SHOW_INVALID_POSITIONS;
     }
 
     public enum SpeedUnit {
@@ -134,6 +136,18 @@ public class UserSettings implements Serializable {
 
     public void setTimePrintInterval(Short timePrintInterval) {
         this.timePrintInterval = timePrintInterval;
+    }
+
+    @Expose
+    @Column(nullable = true)
+    private Boolean showInvalidPositions;
+
+    public Boolean getShowInvalidPositions() {
+        return showInvalidPositions;
+    }
+
+    public void setShowInvalidPositions(Boolean showInvalidPositions) {
+        this.showInvalidPositions = showInvalidPositions;
     }
 
     @Expose

--- a/src/main/resources/org/traccar/web/client/i18n/Messages.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages.properties
@@ -79,6 +79,7 @@ map = Map
 # user settings dialog
 speedUnits = Speed Units
 timePrintInterval = Time stamps print interval
+showInvalidPositions = Show invalid positions
 defaultMapState = Default map state
 zoom = Zoom
 takeFromMap = Take from map

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_de.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_de.properties
@@ -70,6 +70,7 @@ map = Karte
 # user settings dialog
 speedUnits = Geschwindigkeit Einheit
 timePrintInterval = Zeit Stempel Intervall
+showInvalidPositions = Zeigen ungültige positionen
 defaultMapState = Standard Karten Status
 zoom = Zoom
 takeFromMap = Aus Karte nehmen

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_es.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_es.properties
@@ -74,6 +74,7 @@ map = Mapa
 # user settings dialog
 speedUnits = Unidades de velocidad
 timePrintInterval = Intervalo de impresion de tiempos
+showInvalidPositions = Mostrar posiciones no válidas
 defaultMapState = Estado por defecto del mapa
 zoom = Zoom
 takeFromMap = Tomar del mapa

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_hu.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_hu.properties
@@ -74,6 +74,7 @@ map = Térkép
 # user settings dialog
 speedUnits = Sebesség mértékegysége
 timePrintInterval = Időbéllyeg jelzésének intervalluma
+showInvalidPositions = Mutasd érvénytelen pozíciókat
 defaultMapState = Alapértelmezett térkép állapot
 zoom = Nagyítás
 takeFromMap = Vegye a térképről

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_it.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_it.properties
@@ -71,6 +71,7 @@ map = Mappa
 # user settings dialog
 speedUnits = Unità Velocità
 timePrintInterval = Intervalli di Tempo mostrati
+showInvalidPositions = Mostra posizioni non valide
 defaultMapState = Stato di Default della Mappa
 zoom = Zoom
 takeFromMap = Ricava dalla Mappa

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_pl.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_pl.properties
@@ -73,6 +73,7 @@ map = Mapa
 # user settings dialog
 speedUnits = Jednostka pr\u0119dko\u015Bci
 timePrintInterval = Interwa\u0142 stempla czasowego
+showInvalidPositions = Poka\u0142 nieprawid\u0142owe pozycje
 defaultMapState = Status standardowej mapy
 zoom = Zoom
 takeFromMap = Pobierz z mapy

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_ru.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_ru.properties
@@ -79,6 +79,7 @@ map = Карта
 # user settings dialog
 speedUnits = Ед. изм. скорости
 timePrintInterval = Период вывода времени
+showInvalidPositions = Показать неверные позиции
 defaultMapState = Начальное положение карты
 zoom = Масштаб
 takeFromMap = Взять из карты

--- a/src/main/resources/org/traccar/web/client/i18n/Messages_tl.properties
+++ b/src/main/resources/org/traccar/web/client/i18n/Messages_tl.properties
@@ -71,6 +71,7 @@ map = Mapa
 # user settings dialog
 speedUnits = Bilis ng mga unit
 timePrintInterval = Naka-print na selyo na agwat ng oras 
+showInvalidPositions = Ipakita ang mga di-wastong posisyon
 defaultMapState = Estado ng mapa
 zoom = Zoom
 takeFromMap = Kuhanin sa mapa


### PR DESCRIPTION
Note that HQL requires an operator and operand when using BOOLEAN data types (e.g., "WHERE flag = TRUE" as opposed to "WHERE flag").
