### PR TITLE
Adding private constructor to util classes (containing  static methods only)

### DIFF
--- a/src/main/java/org/gwtopenmaps/openlayers/client/format/EncodedPolylineImpl.java
+++ b/src/main/java/org/gwtopenmaps/openlayers/client/format/EncodedPolylineImpl.java
@@ -19,6 +19,9 @@ import org.gwtopenmaps.openlayers.client.util.JSObject;
 
 public class EncodedPolylineImpl
 {
+    private EncodedPolylineImpl() {
+    }
+
     public static native JSObject create()
     /*-{
             return new $wnd.OpenLayers.Format.EncodedPolyline();

--- a/src/main/java/org/traccar/web/client/DateTimeFieldUtil.java
+++ b/src/main/java/org/traccar/web/client/DateTimeFieldUtil.java
@@ -21,6 +21,10 @@ import com.sencha.gxt.widget.core.client.form.TimeField;
 import java.util.Date;
 
 public class DateTimeFieldUtil {
+
+    private DateTimeFieldUtil() {
+    }
+
     @SuppressWarnings("deprecation")
     public static Date getCombineDate(DateField dateField, TimeField timeField) {
         Date result = null;

--- a/src/main/java/org/traccar/web/client/view/MarkerIconFactory.java
+++ b/src/main/java/org/traccar/web/client/view/MarkerIconFactory.java
@@ -25,6 +25,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MarkerIconFactory {
+
+    private MarkerIconFactory() {
+    }
+
     public static Icon getIcon(PositionIcon icon, boolean selected) {
         if (icon == null) {
             return null;

--- a/src/main/java/org/traccar/web/server/model/JacksonUtils.java
+++ b/src/main/java/org/traccar/web/server/model/JacksonUtils.java
@@ -24,6 +24,10 @@ import org.traccar.web.shared.model.DeviceIconType;
 import java.text.SimpleDateFormat;
 
 class JacksonUtils {
+
+    private JacksonUtils() {
+    }
+
     static ObjectMapper create() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/src/main/java/org/traccar/web/server/model/PasswordUtils.java
+++ b/src/main/java/org/traccar/web/server/model/PasswordUtils.java
@@ -21,6 +21,9 @@ import java.util.Random;
 public class PasswordUtils {
     private static final Random RANDOM = new SecureRandom();
 
+    private PasswordUtils() {
+    }
+
     public static String generateRandomString() {
         return generateRandomString(8);
     }

--- a/src/main/java/org/traccar/web/server/reports/PolylineEncoder.java
+++ b/src/main/java/org/traccar/web/server/reports/PolylineEncoder.java
@@ -9,6 +9,10 @@ import java.util.List;
  * See https://developers.google.com/maps/documentation/utilities/polylinealgorithm
  */
 public class PolylineEncoder {
+
+    private PolylineEncoder() {
+    }
+
     private static StringBuilder encodeSignedNumber(int num) {
         int sgn_num = num << 1;
         if (num < 0) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
